### PR TITLE
Update google-cadvisor.yml

### DIFF
--- a/dist/rules/docker-containers/google-cadvisor.yml
+++ b/dist/rules/docker-containers/google-cadvisor.yml
@@ -66,7 +66,16 @@ groups:
       annotations:
         summary: Container Low CPU utilization (instance {{ $labels.instance }})
         description: "Container CPU utilization is under 20% for 1 week. Consider reducing the allocated CPU.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-
+        
+    - alert: ContainerHighLowChangeCpuUsage
+      expr: '(abs((  sum by (instance, name) (rate(container_cpu_usage_seconds_total{name!=""}[1m])) * 100)- (  sum by (instance, name) (rate(container_cpu_usage_seconds_total{name!=""}[1m] offset 1m)) * 100)) or abs((  sum by (instance, name) (rate(container_cpu_usage_seconds_total{name!=""}[1m])) * 100)- (  sum by (instance, name) (rate(container_cpu_usage_seconds_total{name!=""}[5m] offset 1m)) * 100)) )>25'
+      for: 0m
+      labels:
+        severity: info
+      annotations:
+        summary: Container change CPU utilization (instance {{ $labels.instance }})
+        description: "This alert rule monitors the absolute change in CPU usage within a time window and triggers an alert when the change exceeds 25%.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        
     - alert: ContainerLowMemoryUsage
       expr: '(sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) < 20'
       for: 7d


### PR DESCRIPTION
 Expression Explanation:
    The expression calculates the absolute change in CPU usage for containers by comparing the current rate of CPU usage (within the last 1 minute) with the rate of CPU usage from the previous minute. If this change exceeds 25%, the alert is triggered. Additionally, it compares the current rate of CPU usage with the rate from the previous 5 minutes to capture larger trends. If any of these conditions are met, the alert fires.